### PR TITLE
Feat: Extracts and processes spiking data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ database.db
 
 # local run config files
 run_config_*.toml
+
+# scratch folder
+scratch/

--- a/extract_spiketimes.ipynb
+++ b/extract_spiketimes.ipynb
@@ -1,0 +1,700 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "32654688",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "# %matplotlib inline\n",
+    "\n",
+    "import os\n",
+    "import polars as pl\n",
+    "import numpy as np\n",
+    "import spikeinterface.full as si\n",
+    "import matplotlib.pyplot as plt\n",
+    "# import IO_tools as io\n",
+    "from pathlib import Path\n",
+    "from pprint import pprint\n",
+    "from tools.settings import settings\n",
+    "from extract_sync_times import get_recording_sync"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "2a601b43",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "spikeinterface version:  0.102.3\n"
+     ]
+    }
+   ],
+   "source": [
+    "from spikeinterface import __version__ as sivers\n",
+    "print(f'spikeinterface version:  {sivers}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94cb8b6b",
+   "metadata": {},
+   "source": [
+    "## setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "970d2d5b",
+   "metadata": {},
+   "source": [
+    "#### set paths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d5844c88",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Looking for recordings in:\n",
+      "\t/mnt/array/3_TRAP_ISO/1_Recordings\n"
+     ]
+    }
+   ],
+   "source": [
+    "# load config settings\n",
+    "paths = settings.paths\n",
+    "experiment_spiking = settings.experiment\n",
+    "\n",
+    "# define project paths\n",
+    "raw_drive = paths.drive\n",
+    "experiment_name = experiment_spiking.dir\n",
+    "batch_folder = raw_drive / experiment_name / paths.data_dir\n",
+    "metadata_folder = raw_drive / experiment_name / paths.meta_dir\n",
+    "datasets_folder = raw_drive / experiment_name / paths.dataset_dir\n",
+    "print(f'Looking for recordings in:\\n\\t{batch_folder}')\n",
+    "\n",
+    "# define session paths\n",
+    "raw_dir = paths.raw_dir\n",
+    "alignment_dir = paths.alignment_dir\n",
+    "processed_dir = paths.processed_dir\n",
+    "output_dir = paths.output_dir"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36796510",
+   "metadata": {},
+   "source": [
+    "#### set parallel processing parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e99f15ea",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Parallel Job parameters:\n",
+      "{ 'chunk_duration': '5s',\n",
+      "  'n_jobs': 8,\n",
+      "  'progress_bar': True}\n"
+     ]
+    }
+   ],
+   "source": [
+    "job_kwargs=dict(\n",
+    "    n_jobs=8,\n",
+    "    chunk_duration='5s',\n",
+    "    progress_bar=True,\n",
+    ")\n",
+    "\n",
+    "print(\"\\nParallel Job parameters:\")\n",
+    "pprint(job_kwargs, indent=2, width=2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c153122e",
+   "metadata": {},
+   "source": [
+    "## process recordings"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ae2b3c6",
+   "metadata": {},
+   "source": [
+    "#### set subject / recording pairs to process"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5abf4d25",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Processing the following recordings:\n",
+      "{'TRP804_R2': {'concatenate': False, 'multiple_shanks': True}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# change to other than None to compress specific raw recording (including multiple segments)\n",
+    "# e.g. \"NP02_R1\", or keep as None to batch compress all recordings in recording_pairs\n",
+    "recording_name = None\n",
+    "\n",
+    "recording_pairs = experiment_spiking.recordings\n",
+    "if recording_name is not None:\n",
+    "    properties = recording_pairs[recording_name]\n",
+    "    print(f'---processing single recording')\n",
+    "    recording_pairs = {recording_name: properties}\n",
+    "\n",
+    "print(\"Processing the following recordings:\")\n",
+    "pprint(recording_pairs, indent=4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18c01897",
+   "metadata": {},
+   "source": [
+    "#### load alignment data for experiment\n",
+    "the file should have been generated from `postprocess_recordings.ipynb`, and be located in the designated `alignment_dir` for the sessions [set by `default_config.toml`]. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5d39986b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded alignment data:\n",
+      "Total units: 1050\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (3, 16)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th></th><th>unit_id</th><th>brain_region_id</th><th>abbrev</th><th>unit_x</th><th>unit_y</th><th>unit_z</th><th>shank_id</th><th>channel_id</th><th>original_channel_idx</th><th>bregma</th><th>recording_name</th><th>brain_region</th><th>general_region</th><th>very_general_region</th><th>probe_id</th></tr><tr><td>i64</td><td>i64</td><td>f64</td><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>i64</td><td>str</td><td>f64</td><td>str</td><td>str</td><td>str</td><td>str</td><td>str</td><td>i64</td></tr></thead><tbody><tr><td>156</td><td>215</td><td>477.0</td><td>&quot;STR&quot;</td><td>0.0</td><td>0.0</td><td>0.0</td><td>1</td><td>&quot;AP105&quot;</td><td>124.0</td><td>&quot;[5739, 5400, 332]&quot;</td><td>&quot;TRP804_R2&quot;</td><td>&quot;Striatum&quot;</td><td>&quot;Striatum&quot;</td><td>&quot;Striatum&quot;</td><td>0</td></tr><tr><td>167</td><td>233</td><td>477.0</td><td>&quot;STR&quot;</td><td>282.502834</td><td>2652.801408</td><td>120.0</td><td>1</td><td>&quot;AP115&quot;</td><td>129.0</td><td>&quot;[5739, 5400, 332]&quot;</td><td>&quot;TRP804_R2&quot;</td><td>&quot;Striatum&quot;</td><td>&quot;Striatum&quot;</td><td>&quot;Striatum&quot;</td><td>0</td></tr><tr><td>165</td><td>230</td><td>477.0</td><td>&quot;STR&quot;</td><td>282.500755</td><td>2656.795651</td><td>109.248516</td><td>1</td><td>&quot;AP115&quot;</td><td>129.0</td><td>&quot;[5739, 5400, 332]&quot;</td><td>&quot;TRP804_R2&quot;</td><td>&quot;Striatum&quot;</td><td>&quot;Striatum&quot;</td><td>&quot;Striatum&quot;</td><td>0</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (3, 16)\n",
+       "┌─────┬─────────┬──────────────┬────────┬───┬──────────────┬──────────────┬─────────────┬──────────┐\n",
+       "│     ┆ unit_id ┆ brain_region ┆ abbrev ┆ … ┆ brain_region ┆ general_regi ┆ very_genera ┆ probe_id │\n",
+       "│ --- ┆ ---     ┆ _id          ┆ ---    ┆   ┆ ---          ┆ on           ┆ l_region    ┆ ---      │\n",
+       "│ i64 ┆ i64     ┆ ---          ┆ str    ┆   ┆ str          ┆ ---          ┆ ---         ┆ i64      │\n",
+       "│     ┆         ┆ f64          ┆        ┆   ┆              ┆ str          ┆ str         ┆          │\n",
+       "╞═════╪═════════╪══════════════╪════════╪═══╪══════════════╪══════════════╪═════════════╪══════════╡\n",
+       "│ 156 ┆ 215     ┆ 477.0        ┆ STR    ┆ … ┆ Striatum     ┆ Striatum     ┆ Striatum    ┆ 0        │\n",
+       "│ 167 ┆ 233     ┆ 477.0        ┆ STR    ┆ … ┆ Striatum     ┆ Striatum     ┆ Striatum    ┆ 0        │\n",
+       "│ 165 ┆ 230     ┆ 477.0        ┆ STR    ┆ … ┆ Striatum     ┆ Striatum     ┆ Striatum    ┆ 0        │\n",
+       "└─────┴─────────┴──────────────┴────────┴───┴──────────────┴──────────────┴─────────────┴──────────┘"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# load alignment data\n",
+    "assert datasets_folder.exists(), f\"(!) No datasets folder found for experiment: {experiment_spiking}\\nExpected in: {datasets_folder}\\nSkipping...\\n\\n\"\n",
+    "if (alignment_file := next(datasets_folder.glob(f'{experiment_name}*_units_all_final.csv'), None)) is None:\n",
+    "    print(f'(!) No alignment data file found in:  {datasets_folder}\\nSkipping...\\n\\n')\n",
+    "alignment_df = pl.read_csv(alignment_file)\n",
+    "print('Loaded alignment data:')\n",
+    "print('Total units:', alignment_df.height)\n",
+    "alignment_df.head(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33e3fff9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "overwrite = False\n",
+    "\n",
+    "spiking_data = []\n",
+    "for session, properties in recording_pairs.items():\n",
+    "    animal = session.split('_')[0]\n",
+    "    recording_name = session\n",
+    "    concatenate = properties['concatenate']\n",
+    "    print(f'---processing  {recording_name}{\", multiple recordings...\" if concatenate else \"\"}')\n",
+    "\n",
+    "    # find session folder\n",
+    "    rec_folder = batch_folder / animal / recording_name\n",
+    "    if rec_folder.exists():\n",
+    "        print(f'recording session folder:  {rec_folder}')  # top-level\n",
+    "    else:\n",
+    "        print(f'(!) No recording session folder found for:  {rec_folder}\\nSkipping...\\n\\n')\n",
+    "        continue\n",
+    "\n",
+    "    # check for multiple probes, essentially are there multiple .cbin/.bin files?\n",
+    "    raw_folder = rec_folder / raw_dir\n",
+    "    assert raw_folder.exists(), f\"(!) No raw data folder found for recording: {rec_folder}\\nExpected in: {raw_folder}\\nSkipping...\\n\\n\"\n",
+    "    match raw_files := list(raw_folder.rglob(f'{recording_name}*imec*.cbin')):\n",
+    "        case x if len(x) > 1:\n",
+    "            print(f'Found multiple raw files for {recording_name}: {x}')\n",
+    "        case _:\n",
+    "            print(f'Found single raw file for {recording_name}: {raw_files}')\n",
+    "\n",
+    "    for probe_num, raw_file in enumerate(raw_files):\n",
+    "        print(f'---processing probe {probe_num} from file: {raw_file.name}')\n",
+    "\n",
+    "        # get session metadata\n",
+    "        session_alignment = alignment_df.filter(\n",
+    "            pl.col('recording_name')==recording_name,  # match recording name\n",
+    "            pl.col('probe_id')==probe_num  # match probe number\n",
+    "            )\n",
+    "        if session_alignment.height == 0:\n",
+    "            print(f'(!) No units or alignment data found for {recording_name} probe {probe_num}\\nSkipping...\\n\\n')\n",
+    "            continue\n",
+    "\n",
+    "        # %% get sync times if not already present\n",
+    "        data_output = rec_folder / output_dir\n",
+    "        ping_samples, ping_times = get_recording_sync(\n",
+    "            raw_file=raw_file,\n",
+    "            rec_folder=rec_folder,\n",
+    "            probe_num=probe_num,\n",
+    "            overwrite=overwrite,\n",
+    "            threshold=40,\n",
+    "            sync_job_kwargs=dict(n_jobs=8, chunk_duration='10s', progress_bar=True)\n",
+    "        )\n",
+    "        if ping_samples is None: # type: ignore\n",
+    "            print(f'(!) No ping samples found in existing npy files for probe {probe_num}\\nSkipping...\\n\\n')\n",
+    "            # continue\n",
+    "        \n",
+    "        # %% get spike times\n",
+    "        # load analyzer\n",
+    "        # spike_analyzer = load_spike_analyzer(rec_folder)\n",
+    "        processed_folder = rec_folder / processed_dir\n",
+    "        try:\n",
+    "            analyzer_folder = next(processed_folder.glob(f'*analyzer_clean_probe{probe_num}.zarr'))\n",
+    "        except StopIteration:\n",
+    "           analyzer_folder = next(processed_folder.glob(f'*analyzer_clean.zarr'), None)  # older format\n",
+    "        finally:\n",
+    "            assert analyzer_folder is not None, f\"(!) No analyzer folder found for probe {probe_num}\\nSkipping...\\n\\n\"\n",
+    "\n",
+    "        analyzer = si.load_sorting_analyzer(\n",
+    "            folder=analyzer_folder,\n",
+    "            format=\"zarr\"\n",
+    "        )\n",
+    "        print(f'Loaded existing analyzer from \"{analyzer_folder}\"...')\n",
+    "        print(analyzer, '\\n')\n",
+    "\n",
+    "        # %% assigning metadata\n",
+    "        # general properties\n",
+    "        num_units = len(analyzer.unit_ids)\n",
+    "        analyzer.set_sorting_property('recording_name', [recording_name]*num_units, save=True)\n",
+    "        analyzer.set_sorting_property('animal',[animal]*num_units, save=True)\n",
+    "        analyzer.set_sorting_property('probe_id', [probe_num]*num_units, save=True)\n",
+    "\n",
+    "        for prop in ['brain_region_id', 'abbrev', 'channel_id', 'brain_region', 'general_region']:\n",
+    "            analyzer.set_sorting_property(prop, session_alignment[prop].to_list(), save=False)        \n",
+    "\n",
+    "        # %% extract spike times\n",
+    "        unit_to_channel_dict = {  # map unit ids to channel indices\n",
+    "            row[0]: row[1] \n",
+    "            for row in session_alignment.select(['unit_id', 'original_channel_idx']).iter_rows()\n",
+    "        }\n",
+    "        spikes = analyzer.sorting.to_spike_vector(extremum_channel_inds=unit_to_channel_dict)\n",
+    "        spikes_df = pl.from_numpy(\n",
+    "            spikes[[ 'sample_index', 'unit_index']],\n",
+    "            schema={'sample_index': pl.Int32, 'unit_index': pl.Int32,}\n",
+    "        ).rename({'unit_index': 'unit_id'})\n",
+    "\n",
+    "        # restrict to sync times (experimental period) in recording\n",
+    "        if ping_samples is None or len(ping_samples) < 2: # type: ignore\n",
+    "            print(f'(!) No sync timestamps found for probe {probe_num} in {recording_name}, keeping whole recording...\\n\\n')\n",
+    "            start_sync, end_sync = 0, analyzer.get_num_samples()  # use whole recording\n",
+    "        else:\n",
+    "            start_sync, end_sync = ping_samples[0], ping_samples[-2]\n",
+    "        spikes_df = spikes_df.filter(\n",
+    "            (pl.col('sample_index') >= start_sync) & (pl.col('sample_index') <= end_sync)\n",
+    "        )\n",
+    "        \n",
+    "        unit_data = spikes_df.group_by('unit_id').agg(\n",
+    "            pl.col('sample_index').alias('spike_times'),\n",
+    "            (pl.col('sample_index') / analyzer.sampling_frequency).alias('spike_times_sec'),\n",
+    "            pl.col('sample_index').count().alias('num_spikes'),\n",
+    "            firing_rate=(pl.col('sample_index').count() / (end_sync - start_sync)) * analyzer.sampling_frequency  # Hz\n",
+    "        )\n",
+    "\n",
+    "        # merge unit data\n",
+    "        session_spiking = session_alignment.join(unit_data, on='unit_id', how='inner')\n",
+    "\n",
+    "        # write to session datasets and add to experiment total\n",
+    "        session_spiking_file = data_output / f'{recording_name}_units_spiking_probe{probe_num}.parquet'\n",
+    "        session_spiking.write_parquet(session_spiking_file)\n",
+    "        print(f'Wrote spiking data for {session} probe {probe_num} to:\\n\\t{session_spiking_file}\\n')\n",
+    "        spiking_data.append(session_spiking)\n",
+    "\n",
+    "experiment_spiking = pl.concat(spiking_data, how='diagonal')\n",
+    "experiment_spiking.head(10)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9aebe5a6",
+   "metadata": {},
+   "source": [
+    "### concatenate experiment firing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "08b1779a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded spiking data for TRP803_R1 probe 0 from:\n",
+      "\t/mnt/array/3_TRAP_ISO/1_Recordings/TRP803/TRP803_R1/3_datasets/TRP803_R1_units_spiking_probe0.parquet\n",
+      "\n",
+      "...concatenating data for recording:  TRP803_R1\n",
+      "Loaded spiking data for TRP803_R2 probe 1 from:\n",
+      "\t/mnt/array/3_TRAP_ISO/1_Recordings/TRP803/TRP803_R2/3_datasets/TRP803_R2_units_spiking_probe1.parquet\n",
+      "\n",
+      "...concatenating data for recording:  TRP803_R2\n",
+      "Loaded spiking data for TRP801_R2 probe 0 from:\n",
+      "\t/mnt/array/3_TRAP_ISO/1_Recordings/TRP801/TRP801_R2/3_datasets/TRP801_R2_units_spiking_probe0.parquet\n",
+      "\n",
+      "...concatenating data for recording:  TRP801_R2\n",
+      "Loaded spiking data for TRP804_R1 probe 0 from:\n",
+      "\t/mnt/array/3_TRAP_ISO/1_Recordings/TRP804/TRP804_R1/3_datasets/TRP804_R1_units_spiking_probe0.parquet\n",
+      "\n",
+      "...concatenating data for recording:  TRP804_R1\n",
+      "Loaded spiking data for TRP804_R2 probe 0 from:\n",
+      "\t/mnt/array/3_TRAP_ISO/1_Recordings/TRP804/TRP804_R2/3_datasets/TRP804_R2_units_spiking_probe0.parquet\n",
+      "\n",
+      "...concatenating data for recording:  TRP804_R2\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (574, 21)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th></th><th>unit_id</th><th>brain_region_id</th><th>abbrev</th><th>unit_x</th><th>unit_y</th><th>unit_z</th><th>shank_id</th><th>channel_id</th><th>original_channel_idx</th><th>bregma</th><th>recording_name</th><th>brain_region</th><th>general_region</th><th>very_general_region</th><th>probe_id</th><th>spike_times</th><th>spike_times_sec</th><th>num_spikes</th><th>firing_rate</th><th>animal</th></tr><tr><td>i64</td><td>i64</td><td>f64</td><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>i64</td><td>str</td><td>f64</td><td>str</td><td>str</td><td>str</td><td>str</td><td>str</td><td>i64</td><td>list[i32]</td><td>list[f64]</td><td>u32</td><td>f64</td><td>str</td></tr></thead><tbody><tr><td>9</td><td>18</td><td>952.0</td><td>&quot;EPd&quot;</td><td>0.0</td><td>205.014458</td><td>116.518117</td><td>0</td><td>&quot;AP26&quot;</td><td>26.0</td><td>&quot;[5739, 5400, 332]&quot;</td><td>&quot;TRP803_R1&quot;</td><td>&quot;Endopiriform nucleus, dorsal p…</td><td>&quot;Cortical subplate&quot;</td><td>&quot;Cortical subplate&quot;</td><td>0</td><td>[1813967, 1814980, … 182557847]</td><td>[60.506215, 60.540005, … 6089.352442]</td><td>83998</td><td>13.932278</td><td>&quot;TRP803&quot;</td></tr><tr><td>99</td><td>146</td><td>672.0</td><td>&quot;CP&quot;</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0</td><td>&quot;AP375&quot;</td><td>283.0</td><td>&quot;[5739, 5400, 332]&quot;</td><td>&quot;TRP803_R1&quot;</td><td>&quot;Caudoputamen&quot;</td><td>&quot;Striatum&quot;</td><td>&quot;Striatum&quot;</td><td>0</td><td>[1813213, 1814812, … 182552800]</td><td>[60.481065, 60.534401, … 6089.184095]</td><td>126754</td><td>21.023977</td><td>&quot;TRP803&quot;</td></tr><tr><td>14</td><td>24</td><td>952.0</td><td>&quot;EPd&quot;</td><td>0.0</td><td>253.731895</td><td>110.051909</td><td>0</td><td>&quot;AP34&quot;</td><td>34.0</td><td>&quot;[5739, 5400, 332]&quot;</td><td>&quot;TRP803_R1&quot;</td><td>&quot;Endopiriform nucleus, dorsal p…</td><td>&quot;Cortical subplate&quot;</td><td>&quot;Cortical subplate&quot;</td><td>0</td><td>[1815293, 1819776, … 182561559]</td><td>[60.550445, 60.699979, … 6089.476258]</td><td>98197</td><td>16.287387</td><td>&quot;TRP803&quot;</td></tr><tr><td>2</td><td>3</td><td>952.0</td><td>&quot;EPd&quot;</td><td>0.0</td><td>41.27799</td><td>111.197747</td><td>0</td><td>&quot;AP6&quot;</td><td>6.0</td><td>&quot;[5739, 5400, 332]&quot;</td><td>&quot;TRP803_R1&quot;</td><td>&quot;Endopiriform nucleus, dorsal p…</td><td>&quot;Cortical subplate&quot;</td><td>&quot;Cortical subplate&quot;</td><td>0</td><td>[1814755, 1815948, … 182551894]</td><td>[60.5325, 60.572293, … 6089.153875]</td><td>46802</td><td>7.762786</td><td>&quot;TRP803&quot;</td></tr><tr><td>7</td><td>15</td><td>952.0</td><td>&quot;EPd&quot;</td><td>0.0</td><td>205.0</td><td>0.0</td><td>0</td><td>&quot;AP22&quot;</td><td>22.0</td><td>&quot;[5739, 5400, 332]&quot;</td><td>&quot;TRP803_R1&quot;</td><td>&quot;Endopiriform nucleus, dorsal p…</td><td>&quot;Cortical subplate&quot;</td><td>&quot;Cortical subplate&quot;</td><td>0</td><td>[1821050, 1823851, … 182559754]</td><td>[60.742474, 60.835903, … 6089.416051]</td><td>26630</td><td>4.416969</td><td>&quot;TRP803&quot;</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>73</td><td>110</td><td>1022.0</td><td>&quot;GPe&quot;</td><td>0.0</td><td>2461.509751</td><td>111.715518</td><td>0</td><td>&quot;AP86&quot;</td><td>35.0</td><td>&quot;[5739, 5400, 332]&quot;</td><td>&quot;TRP804_R2&quot;</td><td>&quot;Globus pallidus, external segm…</td><td>&quot;Pallidum&quot;</td><td>&quot;Pallidum&quot;</td><td>0</td><td>[1078, 10196, … 187390730]</td><td>[0.035957, 0.340095, … 6250.55684]</td><td>23050</td><td>3.687503</td><td>&quot;TRP804&quot;</td></tr><tr><td>85</td><td>131</td><td>966.0</td><td>&quot;EPv&quot;</td><td>250.0</td><td>1010.0</td><td>14.248032</td><td>1</td><td>&quot;AP284&quot;</td><td>150.0</td><td>&quot;[5739, 5400, 332]&quot;</td><td>&quot;TRP804_R2&quot;</td><td>&quot;Endopiriform nucleus, ventral …</td><td>&quot;Cortical subplate&quot;</td><td>&quot;Cortical subplate&quot;</td><td>0</td><td>[509, 1589, … 187394338]</td><td>[0.016978, 0.053002, … 6250.677188]</td><td>46334</td><td>7.41244</td><td>&quot;TRP804&quot;</td></tr><tr><td>70</td><td>104</td><td>1022.0</td><td>&quot;GPe&quot;</td><td>0.0</td><td>2480.918602</td><td>57.394618</td><td>0</td><td>&quot;AP86&quot;</td><td>35.0</td><td>&quot;[5739, 5400, 332]&quot;</td><td>&quot;TRP804_R2&quot;</td><td>&quot;Globus pallidus, external segm…</td><td>&quot;Pallidum&quot;</td><td>&quot;Pallidum&quot;</td><td>0</td><td>[919, 1800, … 187392252]</td><td>[0.030654, 0.06004, … 6250.607608]</td><td>37114</td><td>5.937439</td><td>&quot;TRP804&quot;</td></tr><tr><td>183</td><td>256</td><td>966.0</td><td>&quot;EPv&quot;</td><td>500.000009</td><td>2009.499392</td><td>115.230734</td><td>2</td><td>&quot;AP172&quot;</td><td>198.0</td><td>&quot;[5739, 5400, 332]&quot;</td><td>&quot;TRP804_R2&quot;</td><td>&quot;Endopiriform nucleus, ventral …</td><td>&quot;Cortical subplate&quot;</td><td>&quot;Cortical subplate&quot;</td><td>0</td><td>[1094, 2447, … 187383963]</td><td>[0.036491, 0.081622, … 6250.331122]</td><td>13062</td><td>2.089638</td><td>&quot;TRP804&quot;</td></tr><tr><td>174</td><td>247</td><td>477.0</td><td>&quot;STR&quot;</td><td>0.0</td><td>0.0</td><td>0.0</td><td>1</td><td>&quot;AP137&quot;</td><td>140.0</td><td>&quot;[5739, 5400, 332]&quot;</td><td>&quot;TRP804_R2&quot;</td><td>&quot;Striatum&quot;</td><td>&quot;Striatum&quot;</td><td>&quot;Striatum&quot;</td><td>0</td><td>[29496, 81158, … 187383652]</td><td>[0.983861, 2.707085, … 6250.320748]</td><td>6491</td><td>1.03842</td><td>&quot;TRP804&quot;</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (574, 21)\n",
+       "┌─────┬─────────┬────────────────┬────────┬───┬────────────────┬────────────┬─────────────┬────────┐\n",
+       "│     ┆ unit_id ┆ brain_region_i ┆ abbrev ┆ … ┆ spike_times_se ┆ num_spikes ┆ firing_rate ┆ animal │\n",
+       "│ --- ┆ ---     ┆ d              ┆ ---    ┆   ┆ c              ┆ ---        ┆ ---         ┆ ---    │\n",
+       "│ i64 ┆ i64     ┆ ---            ┆ str    ┆   ┆ ---            ┆ u32        ┆ f64         ┆ str    │\n",
+       "│     ┆         ┆ f64            ┆        ┆   ┆ list[f64]      ┆            ┆             ┆        │\n",
+       "╞═════╪═════════╪════════════════╪════════╪═══╪════════════════╪════════════╪═════════════╪════════╡\n",
+       "│ 9   ┆ 18      ┆ 952.0          ┆ EPd    ┆ … ┆ [60.506215,    ┆ 83998      ┆ 13.932278   ┆ TRP803 │\n",
+       "│     ┆         ┆                ┆        ┆   ┆ 60.540005, …   ┆            ┆             ┆        │\n",
+       "│     ┆         ┆                ┆        ┆   ┆ 6089.…         ┆            ┆             ┆        │\n",
+       "│ 99  ┆ 146     ┆ 672.0          ┆ CP     ┆ … ┆ [60.481065,    ┆ 126754     ┆ 21.023977   ┆ TRP803 │\n",
+       "│     ┆         ┆                ┆        ┆   ┆ 60.534401, …   ┆            ┆             ┆        │\n",
+       "│     ┆         ┆                ┆        ┆   ┆ 6089.…         ┆            ┆             ┆        │\n",
+       "│ 14  ┆ 24      ┆ 952.0          ┆ EPd    ┆ … ┆ [60.550445,    ┆ 98197      ┆ 16.287387   ┆ TRP803 │\n",
+       "│     ┆         ┆                ┆        ┆   ┆ 60.699979, …   ┆            ┆             ┆        │\n",
+       "│     ┆         ┆                ┆        ┆   ┆ 6089.…         ┆            ┆             ┆        │\n",
+       "│ 2   ┆ 3       ┆ 952.0          ┆ EPd    ┆ … ┆ [60.5325,      ┆ 46802      ┆ 7.762786    ┆ TRP803 │\n",
+       "│     ┆         ┆                ┆        ┆   ┆ 60.572293, …   ┆            ┆             ┆        │\n",
+       "│     ┆         ┆                ┆        ┆   ┆ 6089.15…       ┆            ┆             ┆        │\n",
+       "│ 7   ┆ 15      ┆ 952.0          ┆ EPd    ┆ … ┆ [60.742474,    ┆ 26630      ┆ 4.416969    ┆ TRP803 │\n",
+       "│     ┆         ┆                ┆        ┆   ┆ 60.835903, …   ┆            ┆             ┆        │\n",
+       "│     ┆         ┆                ┆        ┆   ┆ 6089.…         ┆            ┆             ┆        │\n",
+       "│ …   ┆ …       ┆ …              ┆ …      ┆ … ┆ …              ┆ …          ┆ …           ┆ …      │\n",
+       "│ 73  ┆ 110     ┆ 1022.0         ┆ GPe    ┆ … ┆ [0.035957,     ┆ 23050      ┆ 3.687503    ┆ TRP804 │\n",
+       "│     ┆         ┆                ┆        ┆   ┆ 0.340095, …    ┆            ┆             ┆        │\n",
+       "│     ┆         ┆                ┆        ┆   ┆ 6250.55…       ┆            ┆             ┆        │\n",
+       "│ 85  ┆ 131     ┆ 966.0          ┆ EPv    ┆ … ┆ [0.016978,     ┆ 46334      ┆ 7.41244     ┆ TRP804 │\n",
+       "│     ┆         ┆                ┆        ┆   ┆ 0.053002, …    ┆            ┆             ┆        │\n",
+       "│     ┆         ┆                ┆        ┆   ┆ 6250.67…       ┆            ┆             ┆        │\n",
+       "│ 70  ┆ 104     ┆ 1022.0         ┆ GPe    ┆ … ┆ [0.030654,     ┆ 37114      ┆ 5.937439    ┆ TRP804 │\n",
+       "│     ┆         ┆                ┆        ┆   ┆ 0.06004, …     ┆            ┆             ┆        │\n",
+       "│     ┆         ┆                ┆        ┆   ┆ 6250.607…      ┆            ┆             ┆        │\n",
+       "│ 183 ┆ 256     ┆ 966.0          ┆ EPv    ┆ … ┆ [0.036491,     ┆ 13062      ┆ 2.089638    ┆ TRP804 │\n",
+       "│     ┆         ┆                ┆        ┆   ┆ 0.081622, …    ┆            ┆             ┆        │\n",
+       "│     ┆         ┆                ┆        ┆   ┆ 6250.33…       ┆            ┆             ┆        │\n",
+       "│ 174 ┆ 247     ┆ 477.0          ┆ STR    ┆ … ┆ [0.983861,     ┆ 6491       ┆ 1.03842     ┆ TRP804 │\n",
+       "│     ┆         ┆                ┆        ┆   ┆ 2.707085, …    ┆            ┆             ┆        │\n",
+       "│     ┆         ┆                ┆        ┆   ┆ 6250.32…       ┆            ┆             ┆        │\n",
+       "└─────┴─────────┴────────────────┴────────┴───┴────────────────┴────────────┴─────────────┴────────┘"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "overwrite = False\n",
+    "session_datasets = list((raw_drive / experiment_name).rglob(f'*units_spiking_*.parquet'))\n",
+    "# session_datasets\n",
+    "spiking_data = []\n",
+    "for session_data_file in session_datasets:\n",
+    "    session_spiking = pl.scan_parquet(session_data_file).with_columns(\n",
+    "        animal=pl.lit(session_data_file.name.split('_')[0]),\n",
+    "    )\n",
+    "    recording_name = session_spiking.select('recording_name').first().collect()['recording_name'][0]\n",
+    "    probe_num = session_spiking.select('probe_id').first().collect()['probe_id'][0]\n",
+    "    print(f'Loaded spiking data for {recording_name} probe {probe_num} from:\\n\\t{session_data_file}\\n')\n",
+    "    print(f'...concatenating data for recording:  {recording_name}')\n",
+    "    spiking_data.append(session_spiking)\n",
+    "\n",
+    "experiment_spiking = pl.concat(spiking_data, how='diagonal')\n",
+    "experiment_spiking.collect()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "98a5f844",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['Superior colliculus, superficial gray layer',\n",
+       " 'Cuneiform nucleus',\n",
+       " 'amygdalar capsule',\n",
+       " 'Basolateral amygdalar nucleus, ventral part',\n",
+       " 'Superior colliculus, motor related, deep gray layer',\n",
+       " 'Globus pallidus, internal segment',\n",
+       " 'Endopiriform nucleus, dorsal part',\n",
+       " 'Ventral posterolateral nucleus of the thalamus',\n",
+       " 'Pons',\n",
+       " 'corpus callosum, body',\n",
+       " 'Primary somatosensory area, upper limb, layer 6a',\n",
+       " 'Retrosplenial area, ventral part, layer 5',\n",
+       " 'Superior colliculus, motor related, intermediate white layer',\n",
+       " 'Basolateral amygdalar nucleus, posterior part',\n",
+       " 'supra-callosal cerebral white matter',\n",
+       " 'Caudoputamen',\n",
+       " 'Retrosplenial area, ventral part, layer 1',\n",
+       " 'Parabrachial nucleus',\n",
+       " 'Basolateral amygdalar nucleus, anterior part',\n",
+       " 'Primary somatosensory area, unassigned, layer 6a',\n",
+       " 'Piriform-amygdalar area',\n",
+       " 'external capsule',\n",
+       " 'Cortical subplate',\n",
+       " 'Retrosplenial area, dorsal part, layer 2/3',\n",
+       " 'Globus pallidus, external segment',\n",
+       " 'Central amygdalar nucleus, capsular part',\n",
+       " 'Reticular nucleus of the thalamus',\n",
+       " 'Primary somatosensory area, unassigned, layer 6b',\n",
+       " 'Superior colliculus, motor related, intermediate gray layer',\n",
+       " 'Retrosplenial area, dorsal part, layer 5',\n",
+       " 'internal capsule',\n",
+       " None,\n",
+       " 'Midbrain reticular nucleus',\n",
+       " 'Endopiriform nucleus, ventral part',\n",
+       " 'Retrosplenial area, dorsal part, layer 1',\n",
+       " 'Striatum',\n",
+       " 'Piriform area',\n",
+       " 'Midbrain',\n",
+       " 'Lateral amygdalar nucleus']"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "experiment_spiking.unique('brain_region').collect()['brain_region'].to_list()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "22b4cfe6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nulls: 7\n",
+      "Unassigned or null brain regions: 15\n",
+      "Total removed units: 22\n",
+      "Total remaining units: 552\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (552, 18)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>animal</th><th>recording_name</th><th>unit_id</th><th>brain_region_id</th><th>abbrev</th><th>brain_region</th><th>general_region</th><th>probe_id</th><th>channel_id</th><th>original_channel_idx</th><th>unit_x</th><th>unit_y</th><th>unit_z</th><th>bregma</th><th>num_spikes</th><th>spike_times</th><th>spike_times_sec</th><th>firing_rate</th></tr><tr><td>str</td><td>str</td><td>i64</td><td>f64</td><td>str</td><td>str</td><td>str</td><td>i64</td><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>str</td><td>u32</td><td>list[i32]</td><td>list[f64]</td><td>f64</td></tr></thead><tbody><tr><td>&quot;TRP803&quot;</td><td>&quot;TRP803_R1&quot;</td><td>18</td><td>952.0</td><td>&quot;EPd&quot;</td><td>&quot;Endopiriform nucleus, dorsal p…</td><td>&quot;Cortical subplate&quot;</td><td>0</td><td>&quot;AP26&quot;</td><td>26.0</td><td>0.0</td><td>205.014458</td><td>116.518117</td><td>&quot;[5739, 5400, 332]&quot;</td><td>83998</td><td>[1813967, 1814980, … 182557847]</td><td>[60.506215, 60.540005, … 6089.352442]</td><td>13.932278</td></tr><tr><td>&quot;TRP803&quot;</td><td>&quot;TRP803_R1&quot;</td><td>146</td><td>672.0</td><td>&quot;CP&quot;</td><td>&quot;Caudoputamen&quot;</td><td>&quot;Striatum&quot;</td><td>0</td><td>&quot;AP375&quot;</td><td>283.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>&quot;[5739, 5400, 332]&quot;</td><td>126754</td><td>[1813213, 1814812, … 182552800]</td><td>[60.481065, 60.534401, … 6089.184095]</td><td>21.023977</td></tr><tr><td>&quot;TRP803&quot;</td><td>&quot;TRP803_R1&quot;</td><td>24</td><td>952.0</td><td>&quot;EPd&quot;</td><td>&quot;Endopiriform nucleus, dorsal p…</td><td>&quot;Cortical subplate&quot;</td><td>0</td><td>&quot;AP34&quot;</td><td>34.0</td><td>0.0</td><td>253.731895</td><td>110.051909</td><td>&quot;[5739, 5400, 332]&quot;</td><td>98197</td><td>[1815293, 1819776, … 182561559]</td><td>[60.550445, 60.699979, … 6089.476258]</td><td>16.287387</td></tr><tr><td>&quot;TRP803&quot;</td><td>&quot;TRP803_R1&quot;</td><td>3</td><td>952.0</td><td>&quot;EPd&quot;</td><td>&quot;Endopiriform nucleus, dorsal p…</td><td>&quot;Cortical subplate&quot;</td><td>0</td><td>&quot;AP6&quot;</td><td>6.0</td><td>0.0</td><td>41.27799</td><td>111.197747</td><td>&quot;[5739, 5400, 332]&quot;</td><td>46802</td><td>[1814755, 1815948, … 182551894]</td><td>[60.5325, 60.572293, … 6089.153875]</td><td>7.762786</td></tr><tr><td>&quot;TRP803&quot;</td><td>&quot;TRP803_R1&quot;</td><td>15</td><td>952.0</td><td>&quot;EPd&quot;</td><td>&quot;Endopiriform nucleus, dorsal p…</td><td>&quot;Cortical subplate&quot;</td><td>0</td><td>&quot;AP22&quot;</td><td>22.0</td><td>0.0</td><td>205.0</td><td>0.0</td><td>&quot;[5739, 5400, 332]&quot;</td><td>26630</td><td>[1821050, 1823851, … 182559754]</td><td>[60.742474, 60.835903, … 6089.416051]</td><td>4.416969</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;TRP804&quot;</td><td>&quot;TRP804_R2&quot;</td><td>110</td><td>1022.0</td><td>&quot;GPe&quot;</td><td>&quot;Globus pallidus, external segm…</td><td>&quot;Pallidum&quot;</td><td>0</td><td>&quot;AP86&quot;</td><td>35.0</td><td>0.0</td><td>2461.509751</td><td>111.715518</td><td>&quot;[5739, 5400, 332]&quot;</td><td>23050</td><td>[1078, 10196, … 187390730]</td><td>[0.035957, 0.340095, … 6250.55684]</td><td>3.687503</td></tr><tr><td>&quot;TRP804&quot;</td><td>&quot;TRP804_R2&quot;</td><td>131</td><td>966.0</td><td>&quot;EPv&quot;</td><td>&quot;Endopiriform nucleus, ventral …</td><td>&quot;Cortical subplate&quot;</td><td>0</td><td>&quot;AP284&quot;</td><td>150.0</td><td>250.0</td><td>1010.0</td><td>14.248032</td><td>&quot;[5739, 5400, 332]&quot;</td><td>46334</td><td>[509, 1589, … 187394338]</td><td>[0.016978, 0.053002, … 6250.677188]</td><td>7.41244</td></tr><tr><td>&quot;TRP804&quot;</td><td>&quot;TRP804_R2&quot;</td><td>104</td><td>1022.0</td><td>&quot;GPe&quot;</td><td>&quot;Globus pallidus, external segm…</td><td>&quot;Pallidum&quot;</td><td>0</td><td>&quot;AP86&quot;</td><td>35.0</td><td>0.0</td><td>2480.918602</td><td>57.394618</td><td>&quot;[5739, 5400, 332]&quot;</td><td>37114</td><td>[919, 1800, … 187392252]</td><td>[0.030654, 0.06004, … 6250.607608]</td><td>5.937439</td></tr><tr><td>&quot;TRP804&quot;</td><td>&quot;TRP804_R2&quot;</td><td>256</td><td>966.0</td><td>&quot;EPv&quot;</td><td>&quot;Endopiriform nucleus, ventral …</td><td>&quot;Cortical subplate&quot;</td><td>0</td><td>&quot;AP172&quot;</td><td>198.0</td><td>500.000009</td><td>2009.499392</td><td>115.230734</td><td>&quot;[5739, 5400, 332]&quot;</td><td>13062</td><td>[1094, 2447, … 187383963]</td><td>[0.036491, 0.081622, … 6250.331122]</td><td>2.089638</td></tr><tr><td>&quot;TRP804&quot;</td><td>&quot;TRP804_R2&quot;</td><td>247</td><td>477.0</td><td>&quot;STR&quot;</td><td>&quot;Striatum&quot;</td><td>&quot;Striatum&quot;</td><td>0</td><td>&quot;AP137&quot;</td><td>140.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>&quot;[5739, 5400, 332]&quot;</td><td>6491</td><td>[29496, 81158, … 187383652]</td><td>[0.983861, 2.707085, … 6250.320748]</td><td>1.03842</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (552, 18)\n",
+       "┌────────┬────────────┬─────────┬────────────┬───┬────────────┬────────────┬───────────┬───────────┐\n",
+       "│ animal ┆ recording_ ┆ unit_id ┆ brain_regi ┆ … ┆ num_spikes ┆ spike_time ┆ spike_tim ┆ firing_ra │\n",
+       "│ ---    ┆ name       ┆ ---     ┆ on_id      ┆   ┆ ---        ┆ s          ┆ es_sec    ┆ te        │\n",
+       "│ str    ┆ ---        ┆ i64     ┆ ---        ┆   ┆ u32        ┆ ---        ┆ ---       ┆ ---       │\n",
+       "│        ┆ str        ┆         ┆ f64        ┆   ┆            ┆ list[i32]  ┆ list[f64] ┆ f64       │\n",
+       "╞════════╪════════════╪═════════╪════════════╪═══╪════════════╪════════════╪═══════════╪═══════════╡\n",
+       "│ TRP803 ┆ TRP803_R1  ┆ 18      ┆ 952.0      ┆ … ┆ 83998      ┆ [1813967,  ┆ [60.50621 ┆ 13.932278 │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆ 1814980, … ┆ 5, 60.540 ┆           │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆ 182557847… ┆ 005, …    ┆           │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆            ┆ 6089.…    ┆           │\n",
+       "│ TRP803 ┆ TRP803_R1  ┆ 146     ┆ 672.0      ┆ … ┆ 126754     ┆ [1813213,  ┆ [60.48106 ┆ 21.023977 │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆ 1814812, … ┆ 5, 60.534 ┆           │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆ 182552800… ┆ 401, …    ┆           │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆            ┆ 6089.…    ┆           │\n",
+       "│ TRP803 ┆ TRP803_R1  ┆ 24      ┆ 952.0      ┆ … ┆ 98197      ┆ [1815293,  ┆ [60.55044 ┆ 16.287387 │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆ 1819776, … ┆ 5, 60.699 ┆           │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆ 182561559… ┆ 979, …    ┆           │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆            ┆ 6089.…    ┆           │\n",
+       "│ TRP803 ┆ TRP803_R1  ┆ 3       ┆ 952.0      ┆ … ┆ 46802      ┆ [1814755,  ┆ [60.5325, ┆ 7.762786  │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆ 1815948, … ┆ 60.572293 ┆           │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆ 182551894… ┆ , …       ┆           │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆            ┆ 6089.15…  ┆           │\n",
+       "│ TRP803 ┆ TRP803_R1  ┆ 15      ┆ 952.0      ┆ … ┆ 26630      ┆ [1821050,  ┆ [60.74247 ┆ 4.416969  │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆ 1823851, … ┆ 4, 60.835 ┆           │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆ 182559754… ┆ 903, …    ┆           │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆            ┆ 6089.…    ┆           │\n",
+       "│ …      ┆ …          ┆ …       ┆ …          ┆ … ┆ …          ┆ …          ┆ …         ┆ …         │\n",
+       "│ TRP804 ┆ TRP804_R2  ┆ 110     ┆ 1022.0     ┆ … ┆ 23050      ┆ [1078,     ┆ [0.035957 ┆ 3.687503  │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆ 10196, …   ┆ ,         ┆           │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆ 187390730] ┆ 0.340095, ┆           │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆            ┆ …         ┆           │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆            ┆ 6250.55…  ┆           │\n",
+       "│ TRP804 ┆ TRP804_R2  ┆ 131     ┆ 966.0      ┆ … ┆ 46334      ┆ [509,      ┆ [0.016978 ┆ 7.41244   │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆ 1589, …    ┆ ,         ┆           │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆ 187394338] ┆ 0.053002, ┆           │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆            ┆ …         ┆           │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆            ┆ 6250.67…  ┆           │\n",
+       "│ TRP804 ┆ TRP804_R2  ┆ 104     ┆ 1022.0     ┆ … ┆ 37114      ┆ [919,      ┆ [0.030654 ┆ 5.937439  │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆ 1800, …    ┆ ,         ┆           │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆ 187392252] ┆ 0.06004,  ┆           │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆            ┆ …         ┆           │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆            ┆ 6250.607… ┆           │\n",
+       "│ TRP804 ┆ TRP804_R2  ┆ 256     ┆ 966.0      ┆ … ┆ 13062      ┆ [1094,     ┆ [0.036491 ┆ 2.089638  │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆ 2447, …    ┆ ,         ┆           │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆ 187383963] ┆ 0.081622, ┆           │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆            ┆ …         ┆           │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆            ┆ 6250.33…  ┆           │\n",
+       "│ TRP804 ┆ TRP804_R2  ┆ 247     ┆ 477.0      ┆ … ┆ 6491       ┆ [29496,    ┆ [0.983861 ┆ 1.03842   │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆ 81158, …   ┆ ,         ┆           │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆ 187383652] ┆ 2.707085, ┆           │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆            ┆ …         ┆           │\n",
+       "│        ┆            ┆         ┆            ┆   ┆            ┆            ┆ 6250.32…  ┆           │\n",
+       "└────────┴────────────┴─────────┴────────────┴───┴────────────┴────────────┴───────────┴───────────┘"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# clean up total dataset\n",
+    "region_remove_list = [\n",
+    "    'root', 'corpus callosum', 'supra-callosal cerebral white matter', 'internal capsule', 'external capsule', 'white matter'\n",
+    "]\n",
+    "final_experiment_spiking = experiment_spiking.collect()\n",
+    "print(f'Nulls: {final_experiment_spiking.filter(pl.col(\"brain_region\").is_null()).height}')\n",
+    "print(f'Unassigned or null brain regions: {final_experiment_spiking.filter(pl.col(\"brain_region\").is_in(region_remove_list)).height}')\n",
+    "\n",
+    "final_experiment_spiking = (\n",
+    "    final_experiment_spiking\n",
+    "    .filter(\n",
+    "        ~pl.col('brain_region').is_in(region_remove_list))\n",
+    "    .drop_nulls(subset=['brain_region'])\n",
+    "    .select([\n",
+    "        'animal', 'recording_name',\n",
+    "        'unit_id', 'brain_region_id', 'abbrev', 'brain_region', 'general_region', \n",
+    "        'probe_id', 'channel_id', 'original_channel_idx',\n",
+    "        'unit_x', 'unit_y', 'unit_z', 'bregma',\n",
+    "        'num_spikes', 'spike_times', 'spike_times_sec', 'firing_rate'])\n",
+    ")\n",
+    "\n",
+    "print(f'Total removed units: {experiment_spiking.collect().height - final_experiment_spiking.height}')\n",
+    "print(f'Total remaining units: {final_experiment_spiking.height}')\n",
+    "final_experiment_spiking"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "0883589d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# saving total\n",
+    "final_spiking_file = datasets_folder / f'{experiment_name}_units_spiking_all.parquet'\n",
+    "final_experiment_spiking.write_parquet(final_spiking_file)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "np-ephys",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/extract_sync_times.py
+++ b/extract_sync_times.py
@@ -1,0 +1,202 @@
+import numpy as np
+from pprint import pprint
+from pathlib import Path
+from tools.settings import settings
+from scipy.signal import find_peaks
+from tools.spikesorting import load_recording
+from spikeinterface.core import BaseRecording, ChunkRecordingExecutor
+
+# %% functions
+def get_sync_timestamps(
+        recording: BaseRecording,
+        threshold=None,
+        verbose: bool = False,
+        **job_kwargs
+):
+    
+    # executor
+    func = _get_sync_times_chunk
+    init_func = _init_sync_times_chunk
+    init_args = (recording,threshold)
+    executor = ChunkRecordingExecutor(
+        recording,
+        func,
+        init_func,
+        init_args,
+        job_name='get_sync_times',
+        verbose=verbose,
+        handle_returns=True,
+        **job_kwargs
+    )
+    results = executor.run()
+
+    if results is None:
+        return [], []
+
+    ping_samples = []
+    ping_times = []
+
+    for res in results:
+        samples, times = res
+        ping_samples.extend(np.atleast_1d(samples))
+        ping_times.extend(np.atleast_1d(times))
+
+    return np.array(ping_samples), np.array(ping_times)
+
+def _init_sync_times_chunk(recording: BaseRecording, threshold=None):
+    # create local dict for each worker
+    worker_ctx = {}
+    worker_ctx["recording"] = recording
+    worker_ctx["times"] = recording.get_times()
+    worker_ctx["threshold"] = threshold
+    return worker_ctx
+
+def _get_sync_times_chunk(
+        segment_index, start_frame, end_frame, worker_ctx):
+    """
+    A function that will be executed on each chunk.
+    `chunk` is a numpy array (n_samples, n_channels).
+    `start_frame` is the starting sample index of the chunk.
+    `worker_index` is the parallel worker index.
+    `job_kwargs` contains the chunking parameters.
+    """
+    recording = worker_ctx["recording"]
+    times = worker_ctx["times"]
+    threshold = worker_ctx["threshold"]
+
+    traces = recording.get_traces(start_frame=start_frame, end_frame=end_frame, segment_index=segment_index, return_scaled=True)
+    # --- Detection Logic ---
+    if threshold is not None:
+        # Find where the signal crosses the threshold from below
+        crossings = np.where((traces[:-1] < threshold) & (traces[1:] >= threshold))[0]
+        local_peaks = crossings
+    else:
+        # Alternative: Using np.diff and find_peaks
+        diffs = np.diff(traces.squeeze())
+        # Define findpeaks_kwargs inside or pass them as an argument
+        findpeaks_kwargs = dict(height=0.5, prominence=0.5) # Use a sensible height for diffs
+        local_peaks, _ = find_peaks(diffs, **findpeaks_kwargs)
+
+    # Convert local chunk indices to global recording indices
+    # the offset is the start of the *current* chunk
+    ping_samples = local_peaks + start_frame
+    ping_times = times[ping_samples]
+    return ping_samples, ping_times
+
+def get_recording_sync(
+        raw_file: Path,
+        rec_folder: Path,
+        probe_num: int,
+        overwrite: bool = False,
+        threshold=None,
+        verbose: bool = False,
+        sync_job_kwargs: dict = dict(n_jobs=8, chunk_duration='10s', progress_bar=True)
+):
+        global settings
+        output_dir = settings.paths.output_dir
+        ## get sync times
+        # load recording sync channel
+        assert f'imec{probe_num}' in raw_file.name, f"(!) Expected imec{probe_num} in {raw_file.name}\nSkipping...\n\n"
+        raw_sync = load_recording(raw_file, include_sync=True)
+        raw_sync = raw_sync.channel_slice(channel_ids=[raw_sync.channel_ids[-1]]) # type: ignore
+
+        # get ping times - get sample indices
+        data_output = rec_folder / output_dir
+        if not overwrite and len(list(data_output.glob(f'ping*probe{probe_num}.npy'))) > 1:
+            try:
+                ping_samples = np.load(data_output / f'ping_samples_probe{probe_num}.npy')
+                ping_times = np.load(data_output / f'ping_times_probe{probe_num}.npy')
+                print(f'Loaded existing sync timestamps to {data_output}')
+                print(f'Found {len(ping_samples)} sync timestamps for probe {probe_num} in {raw_file.stem}')
+            except Exception as e:
+                print(f'(!) Error loading existing sync timestamps for probe {probe_num} in {raw_file.stem}: {e}\nSkipping...\n\n')
+                return None, None
+        else:
+            ping_samples, ping_times = get_sync_timestamps(raw_sync, threshold=threshold, verbose=verbose, **sync_job_kwargs)
+            if ping_samples.size==0: # type: ignore
+                print(f'(!) No sync timestamps found for probe {probe_num} in {raw_file.stem}\nSkipping...\n\n')
+                return None, None
+            
+            # save to simple npy
+            np.save(data_output / f'ping_samples_probe{probe_num}.npy', ping_samples)
+            np.save(data_output / f'ping_times_probe{probe_num}.npy', ping_times)
+            print(f'Found {len(ping_samples)} sync timestamps for probe {probe_num} in {raw_file.stem}')
+            print(f'Saved sync timestamps to {data_output}')
+        return ping_samples, ping_times
+
+# %% main processing loop
+def get_all_sync():
+    for session, properties in recording_sessions.items():
+        animal = session.split('_')[0]
+        recording_name = session
+        concatenate = properties['concatenate']
+        print(f'---processing  {recording_name}{", multiple recordings..." if concatenate else ""}')
+
+        # find session folder
+        rec_folder = batch_folder / animal / recording_name
+        if rec_folder.exists():
+            print(f'recording session folder:  {rec_folder}')  # top-level
+        else:
+            print(f'(!) No recording session folder found for:  {rec_folder}\nSkipping...\n\n')
+            continue
+
+        # check for multiple probes, essentially are there multiple .cbin/.bin files?
+        raw_folder = rec_folder / raw_dir
+        assert raw_folder.exists(), f"(!) No raw data folder found for recording: {rec_folder}\nExpected in: {raw_folder}\nSkipping...\n\n"
+        match raw_files := list(raw_folder.rglob(f'{recording_name}*imec*.cbin')):
+            case x if len(x) > 1:
+                print(f'Found multiple raw files for {recording_name}: {x}')
+            case _:
+                print(f'Found single raw file for {recording_name}: {raw_files}')
+
+        # loop over probes
+        for probe_num, raw_file in enumerate(raw_files):
+            print(f'---processing probe {probe_num} from file: {raw_file.name}')
+
+            ## get sync times
+            ping_samples, ping_times = get_recording_sync(
+                raw_file,
+                rec_folder,
+                probe_num,
+                overwrite=overwrite,
+                threshold=None,
+                verbose=True,
+                sync_job_kwargs=dict(n_jobs=8, chunk_duration='10s', progress_bar=True)
+            )
+            if ping_samples is None: # type: ignore
+                print(f'(!) No ping samples found in existing npy files for probe {probe_num}\nSkipping...\n\n')
+                continue
+
+    print('\nFinished processing all recordings.'.upper())
+
+if __name__ == "__main__":
+    from spikeinterface import __version__ as si_vers
+    print(f'spikeinterface version:  {si_vers}')
+
+    # % setup
+    # load config settings
+    paths = settings.paths
+    experiment = settings.experiment
+
+    # define project paths
+    raw_drive = paths.drive
+    experiment_name = experiment.dir
+    batch_folder = raw_drive / experiment_name / paths.data_dir
+    metadata_folder = raw_drive / experiment_name / paths.meta_dir
+    datasets_folder = raw_drive / experiment_name / paths.dataset_dir
+    print(f'Looking for recordings in:\n\t{batch_folder}')
+
+    # define session paths
+    raw_dir = paths.raw_dir
+    alignment_dir = paths.alignment_dir
+    processed_dir = paths.processed_dir
+    output_dir = paths.output_dir
+
+    # set recording sessions to process
+    recording_sessions = experiment.recordings
+    print("Processing the following recordings:")
+    pprint(recording_sessions, indent=4)
+
+    # % parameters
+    overwrite = False
+    get_all_sync()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "pyarrow>=21.0.0,<22",
     "pydantic-settings>=2.10.1",
     "python-dotenv>=1.1.1",
+    "polars>=1.33.0",
 ]
 
 [dependency-groups]

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -1,8 +1,12 @@
+import os
 import pathlib
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict, TomlConfigSettingsSource
 from pydantic import BaseModel
 from typing import Tuple, Type
+from dotenv import load_dotenv, find_dotenv
 
+load_dotenv(find_dotenv("config/.env"))
+run_config_file = os.getenv('RUN_CONFIG_FILE')
 
 class PathsConfig(BaseModel):
     drive: pathlib.Path
@@ -29,7 +33,7 @@ class Settings(BaseSettings):
     experiment: ExperimentConfig
 
     model_config = SettingsConfigDict(
-        toml_file = ["config/default_config.toml", "config/run_config.toml"],
+        toml_file = ["config/default_config.toml", run_config_file if run_config_file else "config/run_config.toml"],
         env_prefix='PIPELINE_',
         env_nested_delimiter='__',
         env_file='config/.env',

--- a/tools/spiketimes.py
+++ b/tools/spiketimes.py
@@ -1,0 +1,35 @@
+import polars as pl
+import numpy as np
+from pathlib import Path
+from spikeinterface.core import BaseRecording, ChunkRecordingExecutor
+
+# %% Helpers
+def load_alignment_data(filename: Path, ):
+    "load alignment table with unit->channelid->brain region info"
+    pass
+
+def get_rec_spikes():
+    'get spikes for duration of recording, start stop ideally from sync signal'
+    pass
+
+def get_spike_times():
+    'get spike times for each unit; sample time to rec time, in secs'
+    pass
+
+def merge_unit_data():
+    pass
+
+
+# def spikes_to_rates():
+#     pass
+
+# - iterate over alignment units
+# - get spike vector, transform as needed and merge
+#   - transform:
+#     - get spikes from rec duration, 
+#     - convert spike times to seconds, from rec start 
+#     - need: start stop, fs, sync (maybe)
+#   - merge with alignment data
+#   - save per recording: alignmenta data + now spike times in secs, drop index if too large
+# - separately, aggregate by animal and then by project
+# ---> analysis scripts

--- a/uv.lock
+++ b/uv.lock
@@ -2097,6 +2097,7 @@ dependencies = [
     { name = "jupyter" },
     { name = "matplotlib" },
     { name = "mtscomp" },
+    { name = "polars" },
     { name = "pyarrow" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
@@ -2122,6 +2123,7 @@ requires-dist = [
     { name = "jupyter", specifier = ">=1.1.1,<2" },
     { name = "matplotlib", specifier = ">=3.9.2,<4" },
     { name = "mtscomp", specifier = ">=1.0.2,<2" },
+    { name = "polars", specifier = ">=1.33.0" },
     { name = "pyarrow", specifier = ">=21.0.0,<22" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
@@ -2544,6 +2546,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/23/e8/21db9c9987b0e728855bd57bff6984f67952bea55d6f75e055c46b5383e8/platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf", size = 21634, upload-time = "2025-08-26T14:32:04.268Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/4b/2028861e724d3bd36227adfa20d3fd24c3fc6d52032f4a93c133be5d17ce/platformdirs-4.4.0-py3-none-any.whl", hash = "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85", size = 18654, upload-time = "2025-08-26T14:32:02.735Z" },
+]
+
+[[package]]
+name = "polars"
+version = "1.33.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/3f/d8bc150b548a486f2559586ec6455c2566b9d2fb7ee1acae90ddca14eec1/polars-1.33.0.tar.gz", hash = "sha256:50ad2ab96c701be2c6ac9b584d9aa6a385f228f6c06de15b88c5d10df7990d56", size = 4811393, upload-time = "2025-09-01T16:32:46.106Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/8c/0c4ac34030348ed547b27db0ae7d77ccd12dc4008e91c4f8e896c3161ed8/polars-1.33.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:664ef1c0988e4098518c6acfdd5477f2e11611f4ac8a269db55b94ea4978d0e5", size = 38793275, upload-time = "2025-09-01T16:31:51.038Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2a/87e27ef3cb76e54f92dd177b9f4c80329d66e78f51ed968e9bdf452ccfb1/polars-1.33.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:2477b720c466914549f0f2cfc69f617a602d91e9d90205b64d795ed1ecf99b3c", size = 35238137, upload-time = "2025-09-01T16:31:55.179Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e2/485c87047e8aaae8dae4e9881517697616b7f79b14132961fbccfc386b29/polars-1.33.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd9b76abc22fdb20a005c629ee8c056b0545433f18854b929fb54e351d1b98ee", size = 39341268, upload-time = "2025-09-01T16:31:58.269Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/3a/39d784ed547832eb6cbe86cc7f3a6353fa977803e0cec743dd5932ecf50b/polars-1.33.0-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:6e78026c2ece38c45c6ee0416e2594980652d89deee13a15bd9f83743ec8fa8d", size = 36262606, upload-time = "2025-09-01T16:32:01.981Z" },
+    { url = "https://files.pythonhosted.org/packages/94/1b/4aea12acf2301f4d7fe78b9f4b54611ec2187439fa299e986974cfd956f2/polars-1.33.0-cp39-abi3-win_amd64.whl", hash = "sha256:7973568178117667871455d7969c1929abb890597964ca89290bfd89e4366980", size = 38919180, upload-time = "2025-09-01T16:32:05.087Z" },
+    { url = "https://files.pythonhosted.org/packages/58/13/824a81b43199202fc859c24515cd5b227930d6dce0dea488e4b415edbaba/polars-1.33.0-cp39-abi3-win_arm64.whl", hash = "sha256:c7d614644eda028907965f8203ac54b9a4f5b90303de2723bf1c1087433a0914", size = 35033820, upload-time = "2025-09-01T16:32:08.116Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds comprehensive functionality to extract and process spike times from electrophysiology recordings:

- A new Jupyter notebook, `extract_spiketimes.ipynb`, orchestrates the loading of sorted unit data, extracts spike times, and merges them with brain region alignment information. It calculates firing rates and filters units from unassigned or white matter regions, then saves both per-session and experiment-wide spiking datasets.
- Implements robust synchronization timestamp extraction via a new module, `extract_sync_times.py`. This module utilizes `spikeinterface`'s `ChunkRecordingExecutor` for efficient, parallel processing of sync channel data, detects sync pulses, and saves the detected timestamps to .npy files.

Integrates `polars` as a new dependency to enhance data manipulation efficiency.

Refactors configuration loading by allowing `run_config.toml` to be defined through a `.env` file, increasing flexibility for different runtime environments.

Adds the `scratch/` directory to `.gitignore` for better repository hygiene.

Introduces `tools/spiketimes.py` as a new module to house future spike-time related utilities.